### PR TITLE
Update about page and project references

### DIFF
--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -5,7 +5,7 @@ permalink: /about/
 order: 4
 ---
 
-Yo, welcome to my page on the internet. I work as a software and infrastructure engineer at [Masterpoint Consulting](https://masterpoint.io/), where we deliver Infrastructure as Code solutions (IAC) at scale. I enjoy crafting code and solutions for the specific problem at hand. I worked for a season as a quant developer and still enjoy working with options, futures, volatility risk data.
+I work as a software and infrastructure engineer at [Masterpoint Consulting](https://masterpoint.io/), where we deliver Infrastructure as Code solutions (IAC) at scale. I enjoy crafting code and solutions for the specific problem at hand. I worked for a season as a quant developer and still enjoy working with options, futures, volatility risk data.
 
 ## Connect
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: ""
 <h2 style="font-size: 13px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin: 2rem 0 0.75rem;">Projects</h2>
 
 **Quant Finance**
-- [nextgentrader](https://github.com/westonplatter/nextgentrader) — automated multi-strategy trading across equities, commodities, and volatility
+- [ngv-trader](https://github.com/westonplatter/ngv-trader) — automated multi-strategy trading across equities, commodities, and volatility
 - [ib_insync_options](https://github.com/westonplatter/ib_insync_options) — option chain data retrieval from Interactive Brokers
 
 **Infrastructure**


### PR DESCRIPTION
## Summary
Minor updates to the about page and project listings to improve clarity and reflect current project naming.

## Changes
- Removed casual greeting ("Yo, ") from the about page introduction for a more professional tone
- Updated the quant finance project reference from `nextgentrader` to `ngv-trader` with the corresponding GitHub repository URL

## Details
The about page now opens with a direct introduction to the role and work, maintaining the same content while presenting a more polished first impression. The project listing has been updated to reflect the current repository name for the automated trading strategy project.

https://claude.ai/code/session_01VAWJYXGQPNaBfQ5pSMbfnt